### PR TITLE
Fix parser for yml2onlineconf

### DIFF
--- a/yml/parser/parser.go
+++ b/yml/parser/parser.go
@@ -92,14 +92,24 @@ func WalkByYML(obj reflect.Value, prefix string, storeNodes bool) map[string]Onl
 		res := WalkByYML(obj.Elem(), prefix, storeNodes)
 		o = mergeMaps(o, res)
 	case reflect.Map:
-		if storeNodes && prefix != "" {
+		if prefix != "" {
 			childrenKeys := []string{}
 			for _, key := range obj.MapKeys() {
 				p := key.Elem().String()
 				childrenKeys = append(childrenKeys, p)
 			}
 			nodePrefix := prefix + "."
-			if len(childrenKeys) > 0 {
+
+			if len(childrenKeys) == 0 {
+				o[prefix] = OnlineConfItem{
+					Key:   prefix,
+					Value: "{}",
+					Type:  "application/x-yaml",
+				}
+				break
+			}
+
+			if storeNodes {
 				sort.Strings(childrenKeys)
 				jsonBytes, err := json.Marshal(childrenKeys)
 				if err != nil {
@@ -109,12 +119,6 @@ func WalkByYML(obj reflect.Value, prefix string, storeNodes bool) map[string]Onl
 				o[nodePrefix] = OnlineConfItem{
 					Key:   nodePrefix,
 					Value: string(jsonBytes),
-					Type:  "application/x-yaml",
-				}
-			} else {
-				o[prefix] = OnlineConfItem{
-					Key:   prefix,
-					Value: "{}",
 					Type:  "application/x-yaml",
 				}
 			}

--- a/yml/parser/parser_test.go
+++ b/yml/parser/parser_test.go
@@ -39,7 +39,7 @@ fee:
             subject: "Simple fee"
   parent_nested:
     sub_parent01: {}
-    sub_parent02: {}
+    reg-exp-.*?@part01\.part02\.part03\.ru: {}
 `)
 
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ fee:
 		},
 		"fee/parent_nested.": {
 			Key:   "fee/parent_nested.",
-			Value: "[\"sub_parent01\",\"sub_parent02\"]",
+			Value: "[\"reg-exp-.*?@part01\\\\.part02\\\\.part03\\\\.ru\",\"sub_parent01\"]",
 			Type:  "application/x-yaml",
 		},
 		"fee/parent_nested/sub_parent01": {
@@ -83,8 +83,8 @@ fee:
 			Value: "{}",
 			Type:  "application/x-yaml",
 		},
-		"fee/parent_nested/sub_parent02": {
-			Key:   "fee/parent_nested/sub_parent02",
+		"fee/parent_nested/reg-exp-.*?@part01\\.part02\\.part03\\.ru": {
+			Key:   "fee/parent_nested/reg-exp-.*?@part01\\.part02\\.part03\\.ru",
 			Value: "{}",
 			Type:  "application/x-yaml",
 		},


### PR DESCRIPTION
Add the fix to parse yaml structure and pass that into onlineconf:
`
pafent_node:
  child_node: {}
`